### PR TITLE
Do not urldecode values that are not part of a url

### DIFF
--- a/src/Falco/RequestValue.fs
+++ b/src/Falco/RequestValue.fs
@@ -48,8 +48,7 @@ module RequestValue =
             acc
 
         let parseRequestPrimitive (x : string) =
-            let decoded = WebUtility.UrlDecode x
-            match decoded with
+            match x with
             | IsNullOrWhiteSpace _ -> RNull
             | IsTrue x
             | IsFalse x -> RBool x
@@ -208,7 +207,7 @@ module RequestValue =
     let private routeKeyValues (route : RouteValueDictionary) =
         route
         |> Seq.map (fun kvp ->
-            kvp.Key, seq { Convert.ToString(kvp.Value, Globalization.CultureInfo.InvariantCulture) })
+            kvp.Key, seq { Convert.ToString(kvp.Value, Globalization.CultureInfo.InvariantCulture) |> WebUtility.UrlDecode })
 
     let private queryKeyValues (query : IQueryCollection) =
         query

--- a/test/Falco.IntegrationTests.App/Program.fs
+++ b/test/Falco.IntegrationTests.App/Program.fs
@@ -54,6 +54,20 @@ let endpoints =
         mapPost "/hello/{name?}" mapRouteData
             (fun person -> Request.mapForm (mapRequestData person) Response.ofJson)
 
+        get "/hello-query"
+            (
+               Request.mapQuery
+                  (fun r ->
+                   let name = r?name.AsStringNonEmpty("world")
+                   $"Hello {name}!") Response.ofPlainText)
+
+        post "/hello-form"
+            (
+               Request.mapForm
+                  (fun r ->
+                   let name = r?name.AsStringNonEmpty("world")
+                   $"Hello {name}!") Response.ofPlainText)
+
         mapGet "/plug/{name?}"
             (fun r -> r?name.AsStringNonEmpty("world"))
             (fun name ctx ->

--- a/test/Falco.IntegrationTests/Program.fs
+++ b/test/Falco.IntegrationTests/Program.fs
@@ -57,10 +57,29 @@ module Tests =
         let content = response.Content.ReadAsStringAsync().Result
         Assert.Equal("""{"Message":"Hello John!"}""", content)
 
+        let response = client.PostAsync("/hello/John+Smith", form).Result
+        let content = response.Content.ReadAsStringAsync().Result
+        Assert.Equal("""{"Message":"Hello John Smith!"}""", content)
+
         use form = new FormUrlEncodedContent(dict [ ("age", "42") ])
         let response = client.PostAsync("/hello/John", form).Result
         let content = response.Content.ReadAsStringAsync().Result
         Assert.Equal("""{"Message":"Hello John, you are 42 years old!"}""", content)
+
+    [<Fact>]
+    let ``Receive mapped form response from: POST /hello-form`` () =
+        use client = factory.CreateClient ()
+        use form = new FormUrlEncodedContent(dict [("name", "Mr ++ ")])
+        let response = client.PostAsync("/hello-form", form).Result
+        let content = response.Content.ReadAsStringAsync().Result
+        Assert.Equal("Hello Mr ++ !", content)
+
+    [<Fact>]
+    let ``Receive mapped query response from: GET /hello-query`` () =
+        use client = factory.CreateClient ()
+        let response = client.GetAsync("/hello-query?name=Mr%20%2B%2B").Result
+        let content = response.Content.ReadAsStringAsync().Result
+        Assert.Equal("Hello Mr ++!", content)
 
     [<Fact>]
     let ``Receive utf8 text/plain response from: GET /plug/name?`` () =


### PR DESCRIPTION
Hello!
I noticed in using Falco that it was stripping `+` from form values as read with the `getForm` helper (and all downstream varients).

It looks like this is because the parsing in `RequestValue` is trying to decode all request data using `WebUtility.UrlDecode`, while the data supplied for query and form values is not url encoded.