### PR TITLE
Fix GetString precision loss for large int64 values

### DIFF
--- a/test/Falco.Tests/RequestTests.fs
+++ b/test/Falco.Tests/RequestTests.fs
@@ -52,6 +52,23 @@ let ``Request.getRouteValues should return Map<string, string> from HttpContext`
     |> should equal "falco"
 
 [<Fact>]
+let ``Request.getRoute should preserve large int64 values as strings`` () =
+    // Regression test for https://github.com/falcoframework/Falco/issues/149
+    let ctx = getHttpContextWriteable false
+    ctx.Request.RouteValues <- RouteValueDictionary()
+    ctx.Request.RouteValues.Add("id", "9223372036854775807") // Int64.MaxValue as string
+
+    let route = Request.getRoute ctx
+
+    // Should return the original string, not scientific notation
+    route.GetString "id"
+    |> should equal "9223372036854775807"
+
+    // Should also be parseable as int64
+    route.GetInt64 "id"
+    |> should equal 9223372036854775807L
+
+[<Fact>]
 let ``Request.mapJson`` () =
     let ctx = getHttpContextWriteable false
     use ms = new MemoryStream(Encoding.UTF8.GetBytes("{\"name\":\"falco\"}"))

--- a/test/Falco.Tests/RequestValueTests.fs
+++ b/test/Falco.Tests/RequestValueTests.fs
@@ -70,6 +70,33 @@ let ``RequestValue should parse int with leading zero as string`` () =
     |> should equal expected
 
 [<Fact>]
+let ``RequestValue should parse large int64 values as string to preserve precision`` () =
+    // Int64.MaxValue = 9223372036854775807 has 19 digits, exceeds float64 precision
+    let expected = RObject [ "id", RString "9223372036854775807" ]
+
+    "id=9223372036854775807"
+    |> RequestValue.parseString
+    |> should equal expected
+
+[<Fact>]
+let ``RequestValue should parse 15 digit integers as RNumber`` () =
+    // 15 digits is within float64 precision
+    let expected = RObject [ "id", RNumber 123456789012345. ]
+
+    "id=123456789012345"
+    |> RequestValue.parseString
+    |> should equal expected
+
+[<Fact>]
+let ``RequestValue should parse 16+ digit integers as RString`` () =
+    // 16+ digits exceeds float64 precision
+    let expected = RObject [ "id", RString "1234567890123456" ]
+
+    "id=1234567890123456"
+    |> RequestValue.parseString
+    |> should equal expected
+
+[<Fact>]
 let ``RequestValue should parse multiple simple pairs`` () =
     let expected = RObject [
         "season", RString "summer"


### PR DESCRIPTION
## Summary

- Fix for #149: `GetString` now correctly returns the original string value for large integers instead of converting to scientific notation

## Problem

`GetString` was converting large integer route values (like `Int64.MaxValue`) to scientific notation, causing precision loss:

```fsharp
ctx.Request.RouteValues.Add("id", "9223372036854775807")  // Int64.MaxValue
let route = Request.getRoute ctx
route.GetString "id"  // Was: "9.223372036854776E+18", Now: "9223372036854775807"
```

## Root Cause

The `IsFloat` pattern was parsing all numeric-looking strings as float64 values. For integers with more than ~15 significant digits, this caused precision loss since float64 only has 15-16 digits of precision.

## Solution

Modified the `IsFloat` pattern to not match integer strings with more than 15 significant digits. Such values now remain as `RString`, preserving the original value exactly.

This doesn't break `GetInt64` because it already handles `RString` values by parsing them directly via `StringParser.parseInt64`.

## Test plan

- [x] Added unit tests for precision boundary (15 vs 16+ digit integers)
- [x] Added regression test for route values with `Int64.MaxValue`
- [x] All 71 existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code). 

I (the human, Michael) couldn't find any place in the contribution docs that was against this, I hope it's ok. (also: want to be transparent about our slow demise as working software devs)